### PR TITLE
カードリストのUI改善

### DIFF
--- a/DB/cardList.storyboard
+++ b/DB/cardList.storyboard
@@ -37,7 +37,7 @@
                                         <rect key="frame" x="0.0" y="28" width="383" height="266"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="GMk-7q-Ypt" id="HHA-hB-STt">
-                                            <rect key="frame" x="0.0" y="0.0" width="383" height="266"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="383" height="265.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="card6.png" translatesAutoresizingMaskIntoConstraints="NO" id="Qlr-kA-Mh2">
@@ -70,19 +70,11 @@
                                                     </connections>
                                                 </button>
                                                 <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hnc-re-WOo">
-                                                    <rect key="frame" x="53" y="206" width="43" height="43"/>
+                                                    <rect key="frame" x="90" y="206" width="43" height="43"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" image="pencil41.png"/>
                                                     <connections>
                                                         <action selector="moveEdit:" destination="nTJ-7Y-I2B" eventType="touchUpInside" id="A15-bt-a4I"/>
-                                                    </connections>
-                                                </button>
-                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Uwy-IA-TQj">
-                                                    <rect key="frame" x="170" y="206" width="43" height="43"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <state key="normal" image="camera3-4.png"/>
-                                                    <connections>
-                                                        <action selector="movePhoto:" destination="nTJ-7Y-I2B" eventType="touchUpInside" id="B6w-fI-OkS"/>
                                                     </connections>
                                                 </button>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kkr-cY-7r8">
@@ -92,13 +84,12 @@
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lVb-q3-W1R">
-                                                    <rect key="frame" x="294" y="206" width="43" height="43"/>
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Uwy-IA-TQj">
+                                                    <rect key="frame" x="230" y="204" width="43" height="43"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="39"/>
-                                                    <state key="normal" title="T"/>
+                                                    <state key="normal" image="camera3-4.png"/>
                                                     <connections>
-                                                        <action selector="makeTweet:" destination="nTJ-7Y-I2B" eventType="touchUpInside" id="oOp-x8-yO1"/>
+                                                        <action selector="movePhoto:" destination="nTJ-7Y-I2B" eventType="touchUpInside" id="B6w-fI-OkS"/>
                                                     </connections>
                                                 </button>
                                             </subviews>
@@ -116,7 +107,6 @@
                                             <outlet property="iconImage" destination="KLK-r3-mKX" id="cMq-Wk-pnQ"/>
                                             <outlet property="introText" destination="Kkr-cY-7r8" id="F8P-iW-WV5"/>
                                             <outlet property="title" destination="ZJH-aq-ICw" id="wGb-t8-QCz"/>
-                                            <outlet property="tweet" destination="lVb-q3-W1R" id="2Ed-St-UZS"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>

--- a/DB/cardList.storyboard
+++ b/DB/cardList.storyboard
@@ -56,19 +56,12 @@
                                                     </connections>
                                                 </button>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZJH-aq-ICw">
-                                                    <rect key="frame" x="142" y="26" width="232" height="31"/>
+                                                    <rect key="frame" x="142" y="27" width="232" height="31"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" name="AmericanTypewriter-Bold" family="American Typewriter" pointSize="18"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cfP-I7-HEV">
-                                                    <rect key="frame" x="142" y="45" width="219" height="150"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <connections>
-                                                        <action selector="moveMap2:" destination="nTJ-7Y-I2B" eventType="touchUpInside" id="Bue-XD-JCw"/>
-                                                    </connections>
-                                                </button>
                                                 <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hnc-re-WOo">
                                                     <rect key="frame" x="90" y="206" width="43" height="43"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -78,7 +71,7 @@
                                                     </connections>
                                                 </button>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kkr-cY-7r8">
-                                                    <rect key="frame" x="154" y="66" width="208" height="134"/>
+                                                    <rect key="frame" x="154" y="67" width="208" height="134"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" name="HiraginoSans-W3" family="Hiragino Sans" pointSize="14"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -103,7 +96,6 @@
                                         </tableViewCellContentView>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <connections>
-                                            <outlet property="MapButton" destination="cfP-I7-HEV" id="8Tt-Lw-WX7"/>
                                             <outlet property="iconImage" destination="KLK-r3-mKX" id="cMq-Wk-pnQ"/>
                                             <outlet property="introText" destination="Kkr-cY-7r8" id="F8P-iW-WV5"/>
                                             <outlet property="title" destination="ZJH-aq-ICw" id="wGb-t8-QCz"/>

--- a/DB/cardList.storyboard
+++ b/DB/cardList.storyboard
@@ -56,8 +56,8 @@
                                                     </connections>
                                                 </button>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZJH-aq-ICw">
-                                                    <rect key="frame" x="142" y="24" width="232" height="31"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <rect key="frame" x="142" y="26" width="232" height="31"/>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" name="AmericanTypewriter-Bold" family="American Typewriter" pointSize="18"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -78,8 +78,8 @@
                                                     </connections>
                                                 </button>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kkr-cY-7r8">
-                                                    <rect key="frame" x="154" y="61" width="208" height="135"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <rect key="frame" x="154" y="66" width="208" height="134"/>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" name="HiraginoSans-W3" family="Hiragino Sans" pointSize="14"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>

--- a/DB/cardList.swift
+++ b/DB/cardList.swift
@@ -138,21 +138,15 @@ class cardList: UIViewController, UITableViewDelegate, UITableViewDataSource{
        
     }
     
-    /* テキストでmap画面へ遷移する */
-    @IBAction func moveMap2(_ sender: Any) {
-        // 押されたボタンを取得
-        let botton = sender as! UIButton
-        let cell = botton.superview?.superview as! setCardList
+    //セルが選択された時に動作する
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         
-        // クリックされたcellの位置を取得
-        let row = tableView.indexPath(for: cell)?.row
-        appDelegate.P_ID = row! + 1
+        appDelegate.P_ID = indexPath.row + 1
         
         let storyboard: UIStoryboard = UIStoryboard(name: "map", bundle: nil)
         let next: UIViewController = storyboard.instantiateInitialViewController()!
         present(next, animated: true, completion: nil)
     }
-    
     /*
     /* map画面へ移動する */
     @IBAction func moveMap(_ sender: Any) {

--- a/DB/cardList.swift
+++ b/DB/cardList.swift
@@ -36,11 +36,6 @@ class cardList: UIViewController, UITableViewDelegate, UITableViewDataSource{
         imageView.image = image
         self.tableView.backgroundView = imageView
         
-        //        NSTimer.scheduledTimerWithTimeInterval(0.5,target:self,selector:Selector("reload"),
-        //            userInfo: nil, repeats: true);
-        
-        
-        //NSTimer.scheduledTimerWithTimeInterval(0.5,target:self,selector:Selector("reload"), userInfo: nil, repeats: true);
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -65,10 +60,6 @@ class cardList: UIViewController, UITableViewDelegate, UITableViewDataSource{
         }
     }
     
-    
-    // functions needed to be implemented
-    // for table view
-    
     // セクション数
     func numberOfSections(in tableView: UITableView) -> Int {
         return 1
@@ -84,15 +75,15 @@ class cardList: UIViewController, UITableViewDelegate, UITableViewDataSource{
         cell.setCell(cards[indexPath.row])
         cell.backgroundColor = UIColor.clear
         cell.contentView.backgroundColor = UIColor.clear
-      
-    /*
-        if appDelegate.flaglist[indexPath.row] == true {
-            cell.flag.tintColor = UIColor.orange
-        }else {
-            cell.flag.tintColor = UIColor.lightGray
-        }
-      */
-
+        
+        /*
+         if appDelegate.flaglist[indexPath.row] == true {
+         cell.flag.tintColor = UIColor.orange
+         }else {
+         cell.flag.tintColor = UIColor.lightGray
+         }
+         */
+        
         return cell
     }
     
@@ -133,11 +124,6 @@ class cardList: UIViewController, UITableViewDelegate, UITableViewDataSource{
         present(next, animated: true, completion: nil)
     }
     
-    /*ツイートを作成する*/
-    @IBAction func makeTweet(_ sender: Any) {
-       
-    }
-    
     //セルが選択された時に動作する
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         
@@ -147,24 +133,6 @@ class cardList: UIViewController, UITableViewDelegate, UITableViewDataSource{
         let next: UIViewController = storyboard.instantiateInitialViewController()!
         present(next, animated: true, completion: nil)
     }
-    /*
-    /* map画面へ移動する */
-    @IBAction func moveMap(_ sender: Any) {
-        print("おおおおお")
-        // 押されたボタンを取得
-        let botton = sender as! UIButton
-        let cell = botton.superview?.superview as! setCardList
-        
-        // クリックされたcellの位置を取得
-        let row = tableView.indexPath(for: cell)?.row
-        appDelegate.P_ID = row! + 1
-        
-        let storyboard: UIStoryboard = UIStoryboard(name: "map", bundle: nil)
-        let next: UIViewController = storyboard.instantiateInitialViewController()!
-        present(next, animated: true, completion: nil)
-    }
- */
-    
     
     /* Facebookみたいな画像の見方ができる関数 */
     @IBAction func openImage(_ sender: Any) {

--- a/DB/setCardList.swift
+++ b/DB/setCardList.swift
@@ -49,11 +49,12 @@ UINavigationControllerDelegate{
         //iPhone6
         if height >= 667 {
             self.title.font = UIFont.boldSystemFont(ofSize:20)
-            self.introText.font = UIFont.systemFont(ofSize: 18)
+            self.introText.font = UIFont.systemFont(ofSize: 17)
             
             //iPhone6 Plus
-            //        }else if height == 736 {
-            //            self.introText.font = UIFont.systemFontOfSize(15)
+                    }else if height == 736 {
+            self.title.font = UIFont.boldSystemFont(ofSize:20)
+            self.introText.font = UIFont.systemFont(ofSize: 17)
             
             //iPhone5・5s・5c
         }else {

--- a/DB/setCardList.swift
+++ b/DB/setCardList.swift
@@ -15,10 +15,8 @@ UINavigationControllerDelegate{
     
 //    @IBOutlet weak var CellButton: UIButton!
     @IBOutlet weak var iconImage: UIImageView!
-    @IBOutlet weak var MapButton: UIButton!
     @IBOutlet weak var title: UILabel!
     @IBOutlet weak var introText: UILabel!
-    @IBOutlet weak var tweet: UIButton!
     
 //    @IBOutlet weak var open_photo: UIButton!
  //   @IBOutlet weak var flag: UIButton!

--- a/DB/setCardList.swift
+++ b/DB/setCardList.swift
@@ -11,16 +11,10 @@ import UIKit
 class setCardList: UITableViewCell, UIImagePickerControllerDelegate,
 UINavigationControllerDelegate{
     
-    
-    
-//    @IBOutlet weak var CellButton: UIButton!
     @IBOutlet weak var iconImage: UIImageView!
     @IBOutlet weak var title: UILabel!
     @IBOutlet weak var introText: UILabel!
-    
-//    @IBOutlet weak var open_photo: UIButton!
- //   @IBOutlet weak var flag: UIButton!
-    
+        
     
     var flagSituation = false
     var cardID = 0
@@ -29,13 +23,10 @@ UINavigationControllerDelegate{
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
     }
     
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
-        
-        // Configure the view for the selected state
     }
     
     func setCell(_ card :cardData) {
@@ -50,7 +41,7 @@ UINavigationControllerDelegate{
             self.introText.font = UIFont.systemFont(ofSize: 17)
             
             //iPhone6 Plus
-                    }else if height == 736 {
+        }else if height == 736 {
             self.title.font = UIFont.boldSystemFont(ofSize:20)
             self.introText.font = UIFont.systemFont(ofSize: 17)
             
@@ -76,39 +67,39 @@ UINavigationControllerDelegate{
     }
     
     /*
-        /* フラグボタンの設定 */
-        flag.setImage(UIImage(named: "favourites7 (1).png")?.withRenderingMode(.alwaysTemplate), for: UIControlState())
-        
-        flagSituation = card.flag
-        
-        flagPaint(flagSituation)
-        
-    }
-    
-    func flagPaint(_ f :Bool){
-        if f == false {
-            flag.tintColor = UIColor.lightGray
-        }else {
-            flag.tintColor = UIColor.orange
-        }
-    }
-    
-    /* フラグボタンを押した時の処理 */
-    @IBAction func flagOnOff(_ sender: AnyObject) {
-        
-        
-        //フラグ登録してなかったら赤に、してたら元どおりに
-        if db.getFlagStatement(appDelegate.P_ID!) == false{
-            flag.tintColor = UIColor.orange
-            db.setFlag(appDelegate.P_ID!, flagStatement: true)
-        } else {
-            flag.tintColor = UIColor.lightGray
-            db.setFlag(appDelegate.P_ID!, flagStatement: false)
-        }
-        
-        appDelegate.flaglist.removeAll()
-        appDelegate.flaglist = DB().getFlagStatementList()
-    }
-    
- */
+     /* フラグボタンの設定 */
+     flag.setImage(UIImage(named: "favourites7 (1).png")?.withRenderingMode(.alwaysTemplate), for: UIControlState())
+     
+     flagSituation = card.flag
+     
+     flagPaint(flagSituation)
+     
+     }
+     
+     func flagPaint(_ f :Bool){
+     if f == false {
+     flag.tintColor = UIColor.lightGray
+     }else {
+     flag.tintColor = UIColor.orange
+     }
+     }
+     
+     /* フラグボタンを押した時の処理 */
+     @IBAction func flagOnOff(_ sender: AnyObject) {
+     
+     
+     //フラグ登録してなかったら赤に、してたら元どおりに
+     if db.getFlagStatement(appDelegate.P_ID!) == false{
+     flag.tintColor = UIColor.orange
+     db.setFlag(appDelegate.P_ID!, flagStatement: true)
+     } else {
+     flag.tintColor = UIColor.lightGray
+     db.setFlag(appDelegate.P_ID!, flagStatement: false)
+     }
+     
+     appDelegate.flaglist.removeAll()
+     appDelegate.flaglist = DB().getFlagStatementList()
+     }
+     
+     */
 }

--- a/Pods/Pods.xcodeproj/xcuserdata/yamataku.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Pods/Pods.xcodeproj/xcuserdata/yamataku.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>Pods-キーコ紀行.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>3</integer>
+		</dict>
+		<key>Pods-キーコ紀行Tests.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>4</integer>
+		</dict>
+		<key>Pods-キーコ紀行UITests.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>5</integer>
+		</dict>
+		<key>Realm.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>6</integer>
+		</dict>
+		<key>RealmSwift.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>7</integer>
+		</dict>
+		<key>SKPhotoBrowser.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>8</integer>
+		</dict>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
「観光する」で最初に遷移する画面：カードリスト画面のUIを変更しました。
・Tボタン（Tweetボタン）を削除
・透明なボタンでmap画面へ遷移していたのを、セルのタップを検知して遷移できるようにした
・iPhone XまでのAutolayoutの制約ができていることを確認
・不要なコードをある程度削除